### PR TITLE
Automated PDF sorting script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,25 @@
 # pdf-sortierer
-Automatisierte Sortierung, Ablage und Verlinkung von PDFs in Ordnerstrukturen
+
+Dieses Projekt automatisiert die Sortierung und Ablage von gescannten PDF-Dateien.  
+Neue PDFs im Ordner `gescannt` werden per OCR ausgelesen, nach konfigurierten Schlagwörtern eingeordnet und in die passenden Unterordner des Ordners `Belege` verschoben.  
+Anschließend wird ein Hyperlink auf die abgelegte Datei in einer Excel-Datei im Ordner `digitale Buchfuehrung` angelegt.
+
+## Vorbereitung
+
+1. Benötigte Pakete installieren (Tesseract, Poppler und Python‑Abhängigkeiten):
+   ```bash
+   apt-get update
+   apt-get install -y tesseract-ocr poppler-utils
+   pip install pytesseract pdf2image watchdog openpyxl
+   ```
+2. Die Datei `config.json` anpassen. Dort sind die Pfade zu den Dropbox-Ordnern und die Schlagwortzuordnung hinterlegt.
+
+## Nutzung
+
+Das Skript `pdf_sorter.py` überwacht den in der Konfiguration angegebenen Ordner und verarbeitet neue PDF-Dateien automatisch:
+
+```bash
+python pdf_sorter.py
+```
+
+Beim Erkennen eines neuen PDFs wird der Text per OCR analysiert, die Datei in den passenden Ordner verschoben und in der Excel‑Liste verlinkt.

--- a/config.json
+++ b/config.json
@@ -1,0 +1,10 @@
+{
+    "input_dir": "~/Dropbox/gescannt",
+    "belege_dir": "~/Dropbox/Belege",
+    "excel_path": "~/Dropbox/digitale Buchfuehrung/belege.xlsx",
+    "category_map": {
+        "lohnabrechnung": "Personalakte Frank/Abrechnungen",
+        "rechnung": "Rechnungen",
+        "miete": "Miete"
+    }
+}

--- a/pdf_sorter.py
+++ b/pdf_sorter.py
@@ -1,0 +1,97 @@
+import os
+import time
+import json
+import shutil
+from datetime import datetime
+from pdf2image import convert_from_path
+import pytesseract
+from openpyxl import Workbook, load_workbook
+from watchdog.observers import Observer
+from watchdog.events import FileSystemEventHandler
+
+
+def load_config(path):
+    with open(path, 'r') as f:
+        config = json.load(f)
+    config['input_dir'] = os.path.expanduser(config['input_dir'])
+    config['belege_dir'] = os.path.expanduser(config['belege_dir'])
+    config['excel_path'] = os.path.expanduser(config['excel_path'])
+    return config
+
+
+def extract_text(pdf_path):
+    text = []
+    images = convert_from_path(pdf_path)
+    for img in images:
+        text.append(pytesseract.image_to_string(img, lang='deu+eng'))
+    return "\n".join(text).lower()
+
+
+def classify(text, category_map):
+    for keyword, folder in category_map.items():
+        if keyword.lower() in text:
+            return folder
+    return None
+
+
+def add_hyperlink(excel_path, file_path):
+    if os.path.exists(excel_path):
+        wb = load_workbook(excel_path)
+        ws = wb.active
+    else:
+        wb = Workbook()
+        ws = wb.active
+        ws.append(["Datum", "Datei", "Pfad"])
+
+    row = [datetime.now().strftime('%Y-%m-%d'), os.path.basename(file_path), file_path]
+    ws.append(row)
+    cell = ws.cell(row=ws.max_row, column=3)
+    cell.hyperlink = file_path
+    cell.style = "Hyperlink"
+    wb.save(excel_path)
+
+
+def process_file(pdf_path, config):
+    text = extract_text(pdf_path)
+    category = classify(text, config['category_map'])
+    if category:
+        dest_dir = os.path.join(config['belege_dir'], category)
+    else:
+        dest_dir = os.path.join(config['belege_dir'], 'Unsortiert')
+    os.makedirs(dest_dir, exist_ok=True)
+    dest_path = os.path.join(dest_dir, os.path.basename(pdf_path))
+    shutil.move(pdf_path, dest_path)
+    add_hyperlink(config['excel_path'], dest_path)
+    print(f"Processed {pdf_path} -> {dest_path}")
+
+
+class PDFHandler(FileSystemEventHandler):
+    def __init__(self, config):
+        self.config = config
+
+    def on_created(self, event):
+        if not event.is_directory and event.src_path.lower().endswith('.pdf'):
+            # give file some time to be written completely
+            time.sleep(1)
+            process_file(event.src_path, self.config)
+
+
+def watch_folder(config):
+    observer = Observer()
+    handler = PDFHandler(config)
+    observer.schedule(handler, path=config['input_dir'], recursive=False)
+    observer.start()
+    print(f"Watching {config['input_dir']} for PDFs...")
+    try:
+        while True:
+            time.sleep(1)
+    except KeyboardInterrupt:
+        observer.stop()
+    observer.join()
+
+
+if __name__ == '__main__':
+    CONFIG_PATH = os.path.join(os.path.dirname(__file__), 'config.json')
+    config = load_config(CONFIG_PATH)
+    os.makedirs(config['input_dir'], exist_ok=True)
+    watch_folder(config)


### PR DESCRIPTION
## Summary
- add config with folder paths and keywords
- implement `pdf_sorter.py` to OCR PDFs, move them to the correct folder and add hyperlinks to Excel
- document setup and usage in README

## Testing
- `python pdf_sorter.py` (observed files processed correctly)


------
https://chatgpt.com/codex/tasks/task_e_686a9a64cc948322a61e23b8745ba1a2